### PR TITLE
Frontend task

### DIFF
--- a/web/modules/custom/server_general/src/ThemeTrait/PersonCardThemeTrait.php
+++ b/web/modules/custom/server_general/src/ThemeTrait/PersonCardThemeTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\server_general\ThemeTrait;
+
+/**
+ * Helper method for rendering Person Card.
+ */
+trait PersonCardThemeTrait {
+  /**
+   * Build a Person card page.
+   *
+   * @param array $data
+   *   Person data.
+   *
+   * @return array
+   *   The render array.
+   */
+  protected function buildElementPersonCard(array $data): array {
+    return [
+      '#theme' => 'server_theme_element__person_card',
+      '#data' => $data,
+    ];
+  }
+
+}

--- a/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
+++ b/web/modules/custom/server_style_guide/src/Controller/StyleGuideController.php
@@ -26,6 +26,7 @@ use Drupal\server_general\ThemeTrait\InfoCardThemeTrait;
 use Drupal\server_general\ThemeTrait\LinkThemeTrait;
 use Drupal\server_general\ThemeTrait\NewsTeasersThemeTrait;
 use Drupal\server_general\ThemeTrait\PeopleTeasersThemeTrait;
+use Drupal\server_general\ThemeTrait\PersonCardThemeTrait;
 use Drupal\server_general\ThemeTrait\QuickLinksThemeTrait;
 use Drupal\server_general\ThemeTrait\QuoteThemeTrait;
 use Drupal\server_general\ThemeTrait\SearchThemeTrait;
@@ -66,7 +67,7 @@ class StyleGuideController extends ControllerBase {
   use TagThemeTrait;
   use TitleAndLabelsThemeTrait;
   use WebformTrait;
-
+  use PersonCardThemeTrait;
 
   /**
    * The link generator service.
@@ -212,6 +213,13 @@ class StyleGuideController extends ControllerBase {
 
     $element = $this->getWebformElement();
     $build[] = $this->wrapElementNoContainer($element, 'Element: Webform');
+
+
+    $element = $this->getPersonCard();
+    $build[] = $this->wrapElementNoContainer($element, 'Person card');
+
+    $element = $this->getPersonCardGrid();
+    $build[] = $this->wrapElementNoContainer($element, 'Person card (Grid)');
 
     return $build;
   }
@@ -646,6 +654,52 @@ class StyleGuideController extends ControllerBase {
   }
 
   /**
+   * Get the Person Card element.
+   *
+   * @return array
+   *   Render array.
+   */
+
+  protected function getPersonCard(): array {
+
+    $data = [
+      [
+        'name' => $this->getRandomName(),
+        'position' => $this->getRandomPosition(),
+        'image' => [$this->getPlaceholderPersonImage(100)][0],
+        'role' => $this->getRandomRole(),
+        'email_link' => 'mailto:example@example.com',
+        'call_link' => 'tel:+123456789',
+      ],
+    ];
+
+    return $this->buildElementPersonCard($data);
+  }
+
+  /**
+   * Get the Person Card Grid element.
+   *
+   * @return array
+   *   Render array.
+   */
+  protected function getPersonCardGrid(): array {
+    $data = [];
+
+    for ($i = 0; $i < 10; $i++) {
+      $data[] = [
+        'name' => $this->getRandomName(),
+        'position' => $this->getRandomPosition(),
+        'image' => [$this->getPlaceholderPersonImage(100)][0],
+        'role' => $this->getRandomRole(),
+        'email_link' => 'mailto:example@example.com',
+        'call_link' => 'tel:+123456789',
+      ];
+    }
+
+    return $this->buildElementPersonCard($data);
+  }
+
+  /**
    * Get the Info cards element.
    *
    * @return array
@@ -880,6 +934,71 @@ class StyleGuideController extends ControllerBase {
     ];
     return $titles[array_rand($titles)];
   }
+
+  /**
+   * Get a random name.
+   *
+   *
+   * @return string
+   *   A random name.
+   */
+  protected function getRandomName(): string {
+    $first_names = [
+      'Jane',
+      'Sara',
+      'John',
+      'Jack',
+    ];
+
+    $last_names = [
+      'Cooper',
+      'Brown',
+      'Williams',
+      'Miller',
+    ];
+
+    $first = $first_names[array_rand($first_names)];
+    $last = $last_names[array_rand($last_names)];
+
+    return "$first $last";
+  }
+
+  /**
+   * Get a random position.
+   *
+   *
+   * @return string
+   *   A random position.
+   */
+  protected function getRandomPosition(): string {
+    $positions = [
+      'Paradigm Representative',
+      'Solutions Strategist',
+      'Experience Architect',
+      'Transformation Advisor',
+    ];
+
+    return $positions[array_rand($positions)];
+  }
+
+  /**
+   * Get a random role.
+   *
+   *
+   * @return string
+   *   A random role.
+   */
+  protected function getRandomRole(): string {
+    $roles = [
+      'Admin',
+      'Super Admin',
+      'Editor',
+      'Viewer',
+    ];
+
+    return $roles[array_rand($roles)];
+  }
+
 
   /**
    * Generate related content.

--- a/web/themes/custom/server_theme/server_theme.theme
+++ b/web/themes/custom/server_theme/server_theme.theme
@@ -266,6 +266,13 @@ function server_theme_theme() {
     ],
   ];
 
+  // Person card template
+  $info['server_theme_element__person_card'] = [
+    'variables' => [
+      'data' => [],
+    ],
+  ];
+
   // A single Button.
   $info['server_theme_button'] = [
     'variables' => [

--- a/web/themes/custom/server_theme/templates/server-theme-element--person-card.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-element--person-card.html.twig
@@ -24,14 +24,14 @@
       </div>
       <div class="grid grid-cols-2 border-t border-gray-200 text-sm text-gray-700 font-medium divide-x-2 divide divide-gray-200">
         <a href="{{ item.email_link }}" class="flex-1 flex items-center justify-center gap-1.5 py-3 hover:bg-gray-50">
-          <svg class="w-6 h-6 text-gray-400 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+          <svg class="w-6 h-6 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
             <path d="M2.038 5.61A2.01 2.01 0 0 0 2 6v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6c0-.12-.01-.238-.03-.352l-.866.65-7.89 6.032a2 2 0 0 1-2.429 0L2.884 6.288l-.846-.677Z"/>
             <path d="M20.677 4.117A1.996 1.996 0 0 0 20 4H4c-.225 0-.44.037-.642.105l.758.607L12 10.742 19.9 4.7l.777-.583Z"/>
           </svg>
           <span>Email</span>
         </a>
         <a href="{{ item.call_link }}" class="flex-1 flex items-center justify-center gap-1.5 py-3 hover:bg-gray-50">
-          <svg class="w-6 h-6 text-gray-400 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+          <svg class="w-6 h-6 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
             <path d="M7.978 4a2.553 2.553 0 0 0-1.926.877C4.233 6.7 3.699 8.751 4.153 10.814c.44 1.995 1.778 3.893 3.456 5.572 1.68 1.679 3.577 3.018 5.57 3.459 2.062.456 4.115-.073 5.94-1.885a2.556 2.556 0 0 0 .001-3.861l-1.21-1.21a2.689 2.689 0 0 0-3.802 0l-.617.618a.806.806 0 0 1-1.14 0l-1.854-1.855a.807.807 0 0 1 0-1.14l.618-.62a2.692 2.692 0 0 0 0-3.803l-1.21-1.211A2.555 2.555 0 0 0 7.978 4Z"/>
           </svg>
           <span>Call</span>

--- a/web/themes/custom/server_theme/templates/server-theme-element--person-card.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-element--person-card.html.twig
@@ -13,7 +13,7 @@
     <div class="w-full max-w-sm bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden">
       <div class="flex flex-col items-center text-center py-6 px-4">
         <img class="w-24 h-24 rounded-full object-cover" src="{{ item.image }}" alt="{{ item.name }}">
-        <h3 class="mt-4 text-lg font-semibold text-gray-900">{{ item.name }}</h3>
+        <p class="mt-4 text-lg font-semibold text-gray-900">{{ item.name }}</p>
         <p class="text-sm text-gray-500">{{ item.position }}</p>
 
         {% if item.role %}

--- a/web/themes/custom/server_theme/templates/server-theme-element--person-card.html.twig
+++ b/web/themes/custom/server_theme/templates/server-theme-element--person-card.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Template for a Person Card.
+ *
+ * Variables:
+ * - data: Person’s information
+ */
+#}
+
+<div class="flex flex-wrap justify-center gap-3">
+  {% for item in data %}
+    <div class="w-full max-w-sm bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden">
+      <div class="flex flex-col items-center text-center py-6 px-4">
+        <img class="w-24 h-24 rounded-full object-cover" src="{{ item.image }}" alt="{{ item.name }}">
+        <h3 class="mt-4 text-lg font-semibold text-gray-900">{{ item.name }}</h3>
+        <p class="text-sm text-gray-500">{{ item.position }}</p>
+
+        {% if item.role %}
+          <span class="mt-2 inline-block text-sm font-medium text-green-800 bg-green-100 rounded-full px-3 py-1">
+          {{ item.role }}
+        </span>
+        {% endif %}
+      </div>
+      <div class="grid grid-cols-2 border-t border-gray-200 text-sm text-gray-700 font-medium divide-x-2 divide divide-gray-200">
+        <a href="{{ item.email_link }}" class="flex-1 flex items-center justify-center gap-1.5 py-3 hover:bg-gray-50">
+          <svg class="w-6 h-6 text-gray-400 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M2.038 5.61A2.01 2.01 0 0 0 2 6v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6c0-.12-.01-.238-.03-.352l-.866.65-7.89 6.032a2 2 0 0 1-2.429 0L2.884 6.288l-.846-.677Z"/>
+            <path d="M20.677 4.117A1.996 1.996 0 0 0 20 4H4c-.225 0-.44.037-.642.105l.758.607L12 10.742 19.9 4.7l.777-.583Z"/>
+          </svg>
+          <span>Email</span>
+        </a>
+        <a href="{{ item.call_link }}" class="flex-1 flex items-center justify-center gap-1.5 py-3 hover:bg-gray-50">
+          <svg class="w-6 h-6 text-gray-400 dark:text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M7.978 4a2.553 2.553 0 0 0-1.926.877C4.233 6.7 3.699 8.751 4.153 10.814c.44 1.995 1.778 3.893 3.456 5.572 1.68 1.679 3.577 3.018 5.57 3.459 2.062.456 4.115-.073 5.94-1.885a2.556 2.556 0 0 0 .001-3.861l-1.21-1.21a2.689 2.689 0 0 0-3.802 0l-.617.618a.806.806 0 0 1-1.14 0l-1.854-1.855a.807.807 0 0 1 0-1.14l.618-.62a2.692 2.692 0 0 0 0-3.803l-1.21-1.211A2.555 2.555 0 0 0 7.978 4Z"/>
+          </svg>
+          <span>Call</span>
+        </a>
+      </div>
+    </div>
+  {% endfor %}
+</div>
+


### PR DESCRIPTION
Included in this PR: 
- Person Card component: renders a single styled card following the Figma design
- Person Card Grid: renders a responsive grid of 10 randomly generated Person Cards
- Integration into the /style-guide page at the bottom of the listing
- [Figma](https://www.figma.com/design/r1kH05IrINkSRPTDGi665K/Home-assignment---TailwindCSS?node-id=1-1180&p=f&t=QycurGP9EK65Nuhw-0)

Screenshots:
Single Person Card
Person Card Grid
Responsive behavior on different screen sizes

<img width="1703" height="924" alt="Screenshot 2025-09-04 at 16 46 17" src="https://github.com/user-attachments/assets/c053cd68-5bf4-4f82-815d-245da4401b00" />
<img width="1706" height="926" alt="Screenshot 2025-09-04 at 16 46 39" src="https://github.com/user-attachments/assets/c5fdc273-7bd4-4ba1-9313-b34a7dc6b61c" />
<img width="1708" height="602" alt="Screenshot 2025-09-04 at 16 47 08" src="https://github.com/user-attachments/assets/65f63890-780a-4472-8cba-db26cffe2494" />
<img width="1704" height="862" alt="Screenshot 2025-09-04 at 16 47 39" src="https://github.com/user-attachments/assets/c417b2c0-a85b-4abc-9c6b-661547f88cbe" />
